### PR TITLE
added some newtypes

### DIFF
--- a/package.yaml
+++ b/package.yaml
@@ -62,6 +62,8 @@ dependencies:
 - mtl
 - retry
 - async
+- persistent
+- scientific
 
 library:
   source-dirs: src

--- a/src/LndClient/Data/AddInvoice.hs
+++ b/src/LndClient/Data/AddInvoice.hs
@@ -13,21 +13,22 @@ import Data.ByteString.Base64 (encode)
 import Data.Text (Text)
 import Data.Text.Encoding (decodeUtf8, encodeUtf8)
 import GHC.Generics (Generic)
+import LndClient.Data.Newtypes
 import LndClient.Utils (stdParseJSON, stdToJSON)
 
 data AddInvoiceRequest
   = AddInvoiceRequest
       { memo :: Maybe Text,
-        value :: Integer,
+        value :: MoneyAmount,
         descriptionHash :: Maybe Text
       }
   deriving (Generic, Show)
 
 data AddInvoiceResponse
   = AddInvoiceResponse
-      { rHash :: Text,
-        paymentRequest :: Text,
-        addIndex :: Text
+      { rHash :: RHash,
+        paymentRequest :: PaymentRequest,
+        addIndex :: AddIndex
       }
   deriving (Generic, Show, Eq)
 

--- a/src/LndClient/Data/Invoice.hs
+++ b/src/LndClient/Data/Invoice.hs
@@ -9,6 +9,7 @@ where
 import Data.Aeson (FromJSON (..))
 import Data.Text (Text)
 import GHC.Generics (Generic)
+import LndClient.Data.Newtypes
 import LndClient.Utils (stdParseJSON)
 
 newtype ResultWrapper a
@@ -22,11 +23,11 @@ instance (FromJSON a) => FromJSON (ResultWrapper a) where
 
 data Invoice
   = Invoice
-      { rHash :: Text,
+      { rHash :: RHash,
         amtPaidSat :: Maybe Text,
         creationDate :: Text,
         settleDate :: Maybe Text,
-        value :: Text,
+        value :: MoneyAmount,
         expiry :: Text,
         settled :: Maybe Bool,
         settleIndex :: Maybe Text,

--- a/src/LndClient/Data/Newtypes.hs
+++ b/src/LndClient/Data/Newtypes.hs
@@ -1,0 +1,53 @@
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+
+module LndClient.Data.Newtypes
+  ( AddIndex (..),
+    PaymentRequest (..),
+    RHash (..),
+    MoneyAmount (..),
+  )
+where
+
+import Data.Aeson (FromJSON (..), ToJSON, Value (..))
+import Data.Scientific (toBoundedInteger)
+import Data.Text (Text, unpack)
+import Database.Persist.Class (PersistField)
+import Text.Read (readMaybe)
+
+newtype AddIndex = AddIndex Int
+  deriving (ToJSON, PersistField, Show, Eq)
+
+newtype PaymentRequest = PaymentRequest Text
+  deriving (FromJSON, ToJSON, PersistField, Show, Eq)
+
+newtype RHash = RHash Text
+  deriving (FromJSON, ToJSON, PersistField, Show, Eq)
+
+newtype MoneyAmount = MoneyAmount Int
+  deriving (ToJSON, PersistField, Show, Eq)
+
+instance FromJSON AddIndex where
+  parseJSON = intParser AddIndex "AddIndex"
+
+instance FromJSON MoneyAmount where
+  parseJSON = intParser MoneyAmount "MoneyAmount"
+
+intParser ::
+  (Integral t, Bounded t, Read t, Monad m) =>
+  (t -> a) ->
+  String ->
+  Value ->
+  m a
+intParser cons label x =
+  case x of
+    Number n ->
+      case toBoundedInteger n of
+        Just i -> return $ cons i
+        Nothing -> failure
+    String s ->
+      case readMaybe $ unpack s of
+        Just i -> return $ cons i
+        Nothing -> failure
+    _ -> failure
+  where
+    failure = fail $ "invalid " <> label <> " " <> show x


### PR DESCRIPTION
In some LND JSON methods types are inconsistent and too generic. I added some newtypes around them, to make them more concrete and reusable. Also added `PersistField` type class derivation to use these newtypes directly in Postgres database without messing around with wrapping-unwrapping