### PR TITLE
2020 10 21 it 0

### DIFF
--- a/lnd-client.cabal
+++ b/lnd-client.cabal
@@ -4,7 +4,7 @@ cabal-version: 1.12
 --
 -- see: https://github.com/sol/hpack
 --
--- hash: 437adaa77ee3db97304533825cd646b3d56c98786adc169d9a599264a30f0ca4
+-- hash: 706ec5dd93ea75feb7eda4bd60ab2adcb527d15e41e7d6209891fbe462a1440c
 
 name:           lnd-client
 version:        0.1.0.0
@@ -43,6 +43,7 @@ library
       LndClient.Data.NewAddress
       LndClient.Data.Newtype
       LndClient.Data.OpenChannel
+      LndClient.Data.PayReq
       LndClient.Data.Peer
       LndClient.Data.SendPayment
       LndClient.Data.SubscribeChannelEvents

--- a/src/LndClient/Data/Newtype.hs
+++ b/src/LndClient/Data/Newtype.hs
@@ -182,6 +182,9 @@ instance ToGrpc RPreimage ByteString where
 instance ToGrpc PaymentRequest GRPC.PayReqString where
   toGrpc = Right . GRPC.PayReqString . coerce
 
+instance ToGrpc RHash GRPC.PaymentHash where
+  toGrpc = Right . GRPC.PaymentHash mempty . coerce
+
 newRHash :: RPreimage -> RHash
 newRHash = RHash . SHA256.hash . coerce
 

--- a/src/LndClient/Data/Newtype.hs
+++ b/src/LndClient/Data/Newtype.hs
@@ -37,6 +37,7 @@ import LndClient.Class
 import LndClient.Data.Type
 import LndClient.Import.External
 import LndClient.Util
+import qualified LndGrpc as GRPC
 import Prelude (Show (..))
 
 newtype NodePubKey = NodePubKey ByteString
@@ -139,6 +140,18 @@ instance FromGrpc PaymentRequest Text where
 instance FromGrpc PaymentRequest GRPC.AddHoldInvoiceResp where
   fromGrpc = fromGrpc . GRPC.addHoldInvoiceRespPaymentRequest
 
+instance FromGrpc Seconds Int64 where
+  fromGrpc =
+    (Seconds <$>)
+      . maybeToRight (FromGrpcError "Seconds overflow")
+      . safeFromIntegral
+
+instance FromGrpc RHash Text where
+  fromGrpc x =
+    case B16.decode $ encodeUtf8 x of
+      (y, "") -> Right $ RHash y
+      _ -> Left $ FromGrpcError "NON_HEX_RHASH"
+
 instance ToGrpc PaymentRequest Text where
   toGrpc x = Right (coerce x :: Text)
 
@@ -166,11 +179,14 @@ instance ToGrpc RPreimage GRPC.SettleInvoiceMsg where
 instance ToGrpc RPreimage ByteString where
   toGrpc = Right . coerce
 
+instance ToGrpc PaymentRequest GRPC.PayReqString where
+  toGrpc = Right . GRPC.PayReqString . coerce
+
 newRHash :: RPreimage -> RHash
 newRHash = RHash . SHA256.hash . coerce
 
 newRPreimage :: MonadIO m => m RPreimage
-newRPreimage = liftIO (getRandomBytes 32) >>= return . RPreimage
+newRPreimage = RPreimage <$> liftIO (getRandomBytes 32)
 
 newGrpcTimeout :: Int -> Maybe GrpcTimeoutSeconds
 newGrpcTimeout x =

--- a/src/LndClient/Data/PayReq.hs
+++ b/src/LndClient/Data/PayReq.hs
@@ -1,0 +1,22 @@
+module LndClient.Data.PayReq
+  ( PayReq (..),
+  )
+where
+
+import LndClient.Import
+import qualified LndGrpc as GRPC
+
+data PayReq
+  = PayReq
+      { paymentHash :: RHash,
+        numSatoshis :: MoneyAmount,
+        expiry :: Seconds
+      }
+  deriving (Eq)
+
+instance FromGrpc PayReq GRPC.PayReq where
+  fromGrpc x =
+    PayReq
+      <$> fromGrpc (GRPC.payReqPaymentHash x)
+      <*> fromGrpc (GRPC.payReqNumSatoshis x)
+      <*> fromGrpc (GRPC.payReqExpiry x)

--- a/src/LndClient/RPC/Generic.hs
+++ b/src/LndClient/RPC/Generic.hs
@@ -40,6 +40,7 @@ data RpcName
   | GetInfo
   | SendPayment
   | WaitForGrpc
+  | DecodePayReq
   deriving (Generic)
 
 instance ToJSON RpcName

--- a/src/LndClient/RPC/Generic.hs
+++ b/src/LndClient/RPC/Generic.hs
@@ -41,6 +41,7 @@ data RpcName
   | SendPayment
   | WaitForGrpc
   | DecodePayReq
+  | LookupInvoice
   deriving (Generic)
 
 instance ToJSON RpcName

--- a/src/LndClient/RPC/Generic.hs
+++ b/src/LndClient/RPC/Generic.hs
@@ -42,6 +42,7 @@ data RpcName
   | WaitForGrpc
   | DecodePayReq
   | LookupInvoice
+  | EnsureHodlInvoice
   deriving (Generic)
 
 instance ToJSON RpcName

--- a/src/LndClient/RPC/Katip.hs
+++ b/src/LndClient/RPC/Katip.hs
@@ -26,6 +26,7 @@ module LndClient.RPC.Katip
     subscribeChannelEventsQ,
     subscribeHtlcEvents,
     decodePayReq,
+    lookupInvoice,
   )
 where
 

--- a/src/LndClient/RPC/Katip.hs
+++ b/src/LndClient/RPC/Katip.hs
@@ -25,6 +25,7 @@ module LndClient.RPC.Katip
     subscribeChannelEvents,
     subscribeChannelEventsQ,
     subscribeHtlcEvents,
+    decodePayReq,
   )
 where
 

--- a/src/LndClient/RPC/Katip.hs
+++ b/src/LndClient/RPC/Katip.hs
@@ -27,9 +27,13 @@ module LndClient.RPC.Katip
     subscribeHtlcEvents,
     decodePayReq,
     lookupInvoice,
+    ensureHodlInvoice,
   )
 where
 
+import LndClient.Data.AddHodlInvoice as AddHodlInvoice (AddHodlInvoiceRequest (..))
+import LndClient.Data.AddInvoice as AddInvoice (AddInvoiceResponse (..))
+import LndClient.Data.Invoice as Invoice (Invoice (..))
 import LndClient.Import
 import LndClient.RPC.Generic
 import LndClient.RPC.TH
@@ -89,3 +93,24 @@ lazyInitWallet env =
           "Wallet is already initialized, doing nothing"
         return unlockRes
       else initWallet env
+
+ensureHodlInvoice ::
+  (KatipContext m) =>
+  LndEnv ->
+  AddHodlInvoiceRequest ->
+  m (Either LndError AddInvoiceResponse)
+ensureHodlInvoice env req =
+  katipAddContext (sl "RpcName" EnsureHodlInvoice) $ do
+    $(logTM) (newSeverity env InfoS Nothing Nothing) "RPC is running..."
+    let rh = AddHodlInvoice.hash req
+    _ <- addHodlInvoice (env {envLndLogStrategy = logMaskErrors}) req
+    res <- lookupInvoice env rh
+    return $ case res of
+      Left x -> Left x
+      Right x ->
+        Right $
+          AddInvoice.AddInvoiceResponse
+            { AddInvoice.rHash = rh,
+              AddInvoice.paymentRequest = Invoice.paymentRequest x,
+              AddInvoice.addIndex = Invoice.addIndex x
+            }

--- a/src/LndClient/RPC/Silent.hs
+++ b/src/LndClient/RPC/Silent.hs
@@ -26,6 +26,7 @@ module LndClient.RPC.Silent
     subscribeChannelEventsQ,
     subscribeHtlcEvents,
     decodePayReq,
+    lookupInvoice,
   )
 where
 

--- a/src/LndClient/RPC/Silent.hs
+++ b/src/LndClient/RPC/Silent.hs
@@ -25,6 +25,7 @@ module LndClient.RPC.Silent
     subscribeChannelEvents,
     subscribeChannelEventsQ,
     subscribeHtlcEvents,
+    decodePayReq,
   )
 where
 

--- a/src/LndClient/RPC/TH.hs
+++ b/src/LndClient/RPC/TH.hs
@@ -316,6 +316,17 @@ mkRpc k = do
         DecodePayReq
         GRPC.lightningClient
         GRPC.lightningDecodePayReq
+
+    lookupInvoice ::
+      ($(tcc) m) =>
+      LndEnv ->
+      RHash ->
+      m (Either LndError Invoice)
+    lookupInvoice =
+      $(grpcSync)
+        LookupInvoice
+        GRPC.lightningClient
+        GRPC.lightningLookupInvoice
     |]
   where
     tcc = case k of

--- a/src/LndClient/RPC/TH.hs
+++ b/src/LndClient/RPC/TH.hs
@@ -20,6 +20,7 @@ import LndClient.Data.Invoice (Invoice (..))
 import LndClient.Data.ListChannels (Channel (..), ListChannelsRequest (..))
 import LndClient.Data.NewAddress (NewAddressResponse (..))
 import LndClient.Data.OpenChannel (OpenChannelRequest (..))
+import LndClient.Data.PayReq (PayReq (..))
 import LndClient.Data.Peer (ConnectPeerRequest (..), LightningAddress (..), Peer (..))
 import LndClient.Data.SendPayment (SendPaymentRequest (..), SendPaymentResponse (..))
 import LndClient.Data.SubscribeChannelEvents (ChannelEventUpdate (..))
@@ -304,6 +305,17 @@ mkRpc k = do
         handler
         env
         GRPC.SubscribeHtlcEventsRequest {}
+
+    decodePayReq ::
+      ($(tcc) m) =>
+      LndEnv ->
+      PaymentRequest ->
+      m (Either LndError PayReq)
+    decodePayReq =
+      $(grpcSync)
+        DecodePayReq
+        GRPC.lightningClient
+        GRPC.lightningDecodePayReq
     |]
   where
     tcc = case k of

--- a/test/LndClient/RPCSpec.hs
+++ b/test/LndClient/RPCSpec.hs
@@ -18,6 +18,7 @@ import LndClient.Data.AddInvoice as AddInvoice
   )
 import LndClient.Data.CloseChannel (CloseChannelRequest (..))
 import LndClient.Data.ListChannels as LC (Channel (..), ListChannelsRequest (..))
+import LndClient.Data.PayReq as PayReq (PayReq (..))
 import LndClient.Data.SendPayment (SendPaymentRequest (..))
 import LndClient.Import
 import LndClient.QRCode
@@ -35,6 +36,16 @@ spec =
         x <- readLndEnv
         envLndSyncGrpcTimeout x `shouldBe` newGrpcTimeout 59
         envLndAsyncGrpcTimeout x `shouldBe` Nothing
+    describe "decodePayReq" $ do
+      it "succeeds" $ \env -> do
+        let lnd = envLndMerchant env
+        (x0, x1) <- runApp env $ do
+          x0 <- liftLndResult =<< addInvoice lnd addInvoiceRequest
+          x1 <- liftLndResult =<< decodePayReq lnd (AddInvoice.paymentRequest x0)
+          return (x0, x1)
+        PayReq.paymentHash x1 `shouldBe` AddInvoice.rHash x0
+        PayReq.numSatoshis x1 `shouldBe` AddInvoice.value addInvoiceRequest
+        Just (PayReq.expiry x1) `shouldBe` AddInvoice.expiry addInvoiceRequest
     describe "addInvoice" $ do
       it "succeeds" $ \env -> do
         res <- runApp env $ addInvoice (envLndMerchant env) addInvoiceRequest

--- a/test/LndClient/RPCSpec.hs
+++ b/test/LndClient/RPCSpec.hs
@@ -11,12 +11,13 @@ module LndClient.RPCSpec
   )
 where
 
-import LndClient.Data.AddHodlInvoice as Invoice (AddHodlInvoiceRequest (..))
+import LndClient.Data.AddHodlInvoice as HodlInvoice (AddHodlInvoiceRequest (..))
 import LndClient.Data.AddInvoice as AddInvoice
   ( AddInvoiceRequest (..),
     AddInvoiceResponse (..),
   )
 import LndClient.Data.CloseChannel (CloseChannelRequest (..))
+import LndClient.Data.Invoice as Invoice (Invoice (..))
 import LndClient.Data.ListChannels as LC (Channel (..), ListChannelsRequest (..))
 import LndClient.Data.PayReq as PayReq (PayReq (..))
 import LndClient.Data.SendPayment (SendPaymentRequest (..))
@@ -46,6 +47,18 @@ spec =
         PayReq.paymentHash x1 `shouldBe` AddInvoice.rHash x0
         PayReq.numSatoshis x1 `shouldBe` AddInvoice.value addInvoiceRequest
         Just (PayReq.expiry x1) `shouldBe` AddInvoice.expiry addInvoiceRequest
+    describe "lookupInvoice" $ do
+      it "succeeds" $ \env -> do
+        let lnd = envLndMerchant env
+        (x0, x1) <- runApp env $ do
+          x0 <- liftLndResult =<< addInvoice lnd addInvoiceRequest
+          x1 <- liftLndResult =<< lookupInvoice lnd (AddInvoice.rHash x0)
+          return (x0, x1)
+        Invoice.rHash x1 `shouldBe` AddInvoice.rHash x0
+        Invoice.paymentRequest x1 `shouldBe` AddInvoice.paymentRequest x0
+        Invoice.addIndex x1 `shouldBe` AddInvoice.addIndex x0
+        Just (Invoice.memo x1) `shouldBe` AddInvoice.memo addInvoiceRequest
+        Invoice.value x1 `shouldBe` AddInvoice.value addInvoiceRequest
     describe "addInvoice" $ do
       it "succeeds" $ \env -> do
         res <- runApp env $ addInvoice (envLndMerchant env) addInvoiceRequest


### PR DESCRIPTION
New LND RPCs
- `decodePayReq` LN invoice parser
- `lookupInvoice` search invoice by RHash

New composite RPCs
- `ensureHodlInvoice` is similar to `addHodlInvoice` but returns `AddInvoiceResponse` instead of `PaymentRequest`, because it contains `addIndex` which is useful in many cases