### PR TITLE
2020 11 27 it 0

### DIFF
--- a/lnd-client.cabal
+++ b/lnd-client.cabal
@@ -3,8 +3,6 @@ cabal-version: 1.12
 -- This file has been generated from package.yaml by hpack version 0.34.2.
 --
 -- see: https://github.com/sol/hpack
---
--- hash: 5e12855474915d48760c4328112971691ee21746475b19ca762d9b89311c2e08
 
 name:           lnd-client
 version:        0.1.0.0
@@ -72,8 +70,7 @@ library
   hs-source-dirs:
       src
   default-extensions: NoImplicitPrelude MultiParamTypeClasses LambdaCase OverloadedStrings ScopedTypeVariables
-  ghc-options: -Weverything -Werror -Wno-missing-exported-signatures -Wno-missing-import-lists -Wno-missed-specialisations -Wno-all-missed-specialisations -Wno-unsafe -Wno-safe -Wno-missing-local-signatures -Wno-monomorphism-restriction -optl-fuse-ld=gold
-  ld-options: -fuse-ld=gold
+  ghc-options: -Weverything -Werror -Wno-missing-exported-signatures -Wno-missing-import-lists -Wno-missed-specialisations -Wno-all-missed-specialisations -Wno-unsafe -Wno-safe -Wno-missing-local-signatures -Wno-monomorphism-restriction
   build-depends:
       JuicyPixels
     , aeson
@@ -124,8 +121,7 @@ test-suite lnd-client-test
   hs-source-dirs:
       test
   default-extensions: NoImplicitPrelude MultiParamTypeClasses LambdaCase OverloadedStrings ScopedTypeVariables
-  ghc-options: -Weverything -Werror -Wno-missing-exported-signatures -Wno-missing-import-lists -Wno-missed-specialisations -Wno-all-missed-specialisations -Wno-unsafe -Wno-safe -Wno-missing-local-signatures -Wno-monomorphism-restriction -threaded -rtsopts -with-rtsopts=-N -O0 -optl-fuse-ld=gold
-  ld-options: -fuse-ld=gold
+  ghc-options: -Weverything -Werror -Wno-missing-exported-signatures -Wno-missing-import-lists -Wno-missed-specialisations -Wno-all-missed-specialisations -Wno-unsafe -Wno-safe -Wno-missing-local-signatures -Wno-monomorphism-restriction -threaded -rtsopts -with-rtsopts=-N -O0
   build-depends:
       JuicyPixels
     , aeson

--- a/nix/default.nix
+++ b/nix/default.nix
@@ -24,6 +24,7 @@ in
     enableLibraryProfiling = false;
     isLibrary = true;
     doHaddock = false;
+    prePatch = "hpack --force";
     preCheck = ''
       source ./nix/export-test-envs.sh;
       sh ./nix/reset-test-data.sh;

--- a/nix/shell.nix
+++ b/nix/shell.nix
@@ -13,7 +13,7 @@ in
 with pkgs';
 
 let haskell-ide = import (
-      fetchTarball "https://github.com/tim2CF/ultimate-haskell-ide/tarball/08df4330b966dec8b97e3de6045c44551ee3d6af"
+      fetchTarball "https://github.com/tim2CF/ultimate-haskell-ide/tarball/d455f6a3c7f7c363efa65da2ff003dbf3b4228d2"
     ) {inherit vimBackground vimColorScheme;};
     proto3-suite-src = fetchTarball "https://github.com/coingaming/proto3-suite/tarball/45950a3860cbcb3f3177e9725dbdf460d6da9d45";
     proto3-suite = import (proto3-suite-src + "/release.nix") {};

--- a/package.yaml
+++ b/package.yaml
@@ -91,9 +91,9 @@ library:
   - -Wno-safe # Don’t use Safe Haskell warnings
   - -Wno-missing-local-signatures # Warning for polymorphic local bindings; nothing wrong with those.
   - -Wno-monomorphism-restriction # Don’t warn if the monomorphism restriction is used
-  - -optl-fuse-ld=gold
-  ld-options:
-  - -fuse-ld=gold
+  #- -optl-fuse-ld=gold
+  #ld-options:
+  #- -fuse-ld=gold
   dependencies:
   - hspec
 
@@ -124,9 +124,9 @@ tests:
     - -rtsopts
     - -with-rtsopts=-N
     - -O0
-    - -optl-fuse-ld=gold
-    ld-options:
-    - -fuse-ld=gold
+    #- -optl-fuse-ld=gold
+    #ld-options:
+    #- -fuse-ld=gold
     dependencies:
     - lnd-client
     - hspec


### PR DESCRIPTION
Temporary disable gold linker, for some reason if other package depends on lnd-client with gold linker, it breaks with error

```
/nix/store/cl1i6bfqnx48ipakj4px7pb1babzs23j-binutils-2.31.1/bin/ld.gold: --hash-size=31: un
known option
/nix/store/cl1i6bfqnx48ipakj4px7pb1babzs23j-binutils-2.31.1/bin/ld.gold: use the --help opt
ion for usage information
```

maybe we should use lld linker instead

https://github.com/nh2/link-with-lld-example