### PR TITLE
B1 m2 4471 0

### DIFF
--- a/lnd-client.cabal
+++ b/lnd-client.cabal
@@ -93,7 +93,7 @@ library
       DataKinds
       KindSignatures
       StrictData
-  ghc-options: -Weverything -Werror -Wno-missing-export-lists -Wno-missing-exported-signatures -Wno-missing-import-lists -Wno-missed-specialisations -Wno-all-missed-specialisations -Wno-unsafe -Wno-safe -Wno-missing-local-signatures -Wno-monomorphism-restriction
+  ghc-options: -Weverything -Werror -Wno-missing-export-lists -Wno-missing-exported-signatures -Wno-missing-import-lists -Wno-missed-specialisations -Wno-all-missed-specialisations -Wno-unsafe -Wno-safe -Wno-missing-local-signatures
   build-depends:
       JuicyPixels >=3.3.3 && <3.4
     , aeson >=1.4.4.0
@@ -210,7 +210,7 @@ test-suite lnd-client-test
       DataKinds
       KindSignatures
       StrictData
-  ghc-options: -Weverything -Werror -Wno-missing-export-lists -Wno-missing-exported-signatures -Wno-missing-import-lists -Wno-missed-specialisations -Wno-all-missed-specialisations -Wno-unsafe -Wno-safe -Wno-missing-local-signatures -Wno-monomorphism-restriction -threaded -rtsopts -with-rtsopts=-N
+  ghc-options: -Weverything -Werror -Wno-missing-export-lists -Wno-missing-exported-signatures -Wno-missing-import-lists -Wno-missed-specialisations -Wno-all-missed-specialisations -Wno-unsafe -Wno-safe -Wno-missing-local-signatures -threaded -rtsopts -with-rtsopts=-N
   build-depends:
       JuicyPixels >=3.3.3 && <3.4
     , aeson >=1.4.4.0

--- a/package.yaml
+++ b/package.yaml
@@ -95,7 +95,6 @@ ghc-options:
 - -Wno-unsafe # Don’t use Safe Haskell warnings
 - -Wno-safe # Don’t use Safe Haskell warnings
 - -Wno-missing-local-signatures # Warning for polymorphic local bindings; nothing wrong with those.
-- -Wno-monomorphism-restriction # Don’t warn if the monomorphism restriction is used
 
 library: {}
 

--- a/src/LndClient/Data/ChannelPoint.hs
+++ b/src/LndClient/Data/ChannelPoint.hs
@@ -15,11 +15,10 @@ import LndClient.Import
 import qualified Proto.LndGrpc as LnGRPC
 import qualified Proto.LndGrpc_Fields as LnGRPC
 
-data ChannelPoint
-  = ChannelPoint
-      { fundingTxId :: TxId 'Funding,
-        outputIndex :: Vout 'Funding
-      }
+data ChannelPoint = ChannelPoint
+  { fundingTxId :: TxId 'Funding,
+    outputIndex :: Vout 'Funding
+  }
   deriving (Eq, Ord, Show)
 
 instance FromGrpc ChannelPoint LnGRPC.ChannelPoint where
@@ -61,4 +60,5 @@ channelPointParser x =
     _ ->
       Left $ FromGrpcError "Invalid ChannelPoint text"
   where
+    str :: ByteString
     str = encodeUtf8 x

--- a/src/LndClient/Import/External.hs
+++ b/src/LndClient/Import/External.hs
@@ -17,7 +17,10 @@ import Control.Concurrent.STM.TChan as Import
     readTChan,
     writeTChan,
   )
-import Control.Monad.Extra as Import (fromMaybeM)
+import Control.Monad.Extra as Import
+  ( eitherM,
+    fromMaybeM,
+  )
 import Data.Aeson as Import (FromJSON (..), ToJSON, fromJSON)
 import Data.ByteString as Import (ByteString)
 import Data.Coerce as Import (coerce)

--- a/src/LndClient/LndTest.hs
+++ b/src/LndClient/LndTest.hs
@@ -206,6 +206,7 @@ lazyMineInitialCoins = const $ do
   where
     xs = enumerate :: [owner]
     someone = minBound :: owner
+    numOwners :: Integer
     numOwners = fromIntegral $ length xs
 
 lazyConnectNodes :: forall m owner. LndTest m owner => Proxy owner -> m ()
@@ -279,7 +280,7 @@ syncWallets ::
 syncWallets = const $ this 0
   where
     this 30 = do
-      let msg = "SyncWallets attempt limit exceeded"
+      let msg :: Text = "SyncWallets attempt limit exceeded"
       sev <- getSev (minBound :: owner) ErrorS
       $(logTM) sev $ logStr msg
       pure . Left $ LndError msg
@@ -310,7 +311,7 @@ syncPendingChannelsFor owner = this 0
     this 30 = do
       let msg =
             "SyncPendingChannelsFor "
-              <> show owner
+              <> (show owner :: Text)
               <> " attempt limit exceeded"
       sev <- getSev owner ErrorS
       $(logTM) sev $ logStr msg
@@ -385,7 +386,7 @@ cancelAllInvoices =
       error $ "CancelAllInvoices attempt limit exceeded for " <> show owner
     this attempt owner = do
       lnd <- getLndEnv owner
-      let getInvoices =
+      let getInvoices :: m [Invoice] =
             ListInvoices.invoices
               <$> (liftLndResult =<< Lnd.listInvoices lnd listReq)
       is0 <- getInvoices
@@ -412,7 +413,7 @@ closeAllChannels po = do
       peerLocation <- getNodeLocation owner1
       GetInfoResponse peerPubKey _ _ <-
         liftLndResult =<< Lnd.getInfo =<< getLndEnv owner1
-      let getChannels =
+      let getChannels :: m [Channel] =
             liftLndResult
               =<< Lnd.listChannels
                 lnd0

--- a/src/LndClient/RPC/Katip.hs
+++ b/src/LndClient/RPC/Katip.hs
@@ -75,7 +75,7 @@ waitForGrpc env =
               sleep $ MicroSecondsDelay 1000000
               this $ x - 1
         else do
-          let msg = "waitForGrpc attempt limit exceeded"
+          let msg :: Text = "waitForGrpc attempt limit exceeded"
           $(logTM) (newSev env ErrorS) $ logStr msg
           return . Left $ LndError msg
 

--- a/test/LndClient/TestApp.hs
+++ b/test/LndClient/TestApp.hs
@@ -106,6 +106,7 @@ withEnv action = do
                 setupZeroChannels proxyOwner
                 action
   where
+    rmLogEnv :: LogEnv -> IO ()
     rmLogEnv =
       void . liftIO . closeScribes
 


### PR DESCRIPTION
- Implement `unWatchAll`.
- Graceful watcher shutdown which terminates all running subscriptions.
- Proper linking inside watcher, resolved all watcher TODOs.
- Enable back monomorphism restriction for better runtime performance.